### PR TITLE
Allow points and multipoints in locations.geojson

### DIFF
--- a/spec/reference.md
+++ b/spec/reference.md
@@ -56,7 +56,6 @@ In order for a trip planner to provide a user with information about how to requ
 - This file uses a subset of the GeoJSON format, described in [RFC 7946](https://tools.ietf.org/html/rfc7946).
 - The `locations.geojson` file must contain a `FeatureCollection`.
 - A `FeatureCollection` defines various stop locations where riders may request pickup or drop off.
-- Only features with types `LineString`, `MultiLineString`, `Polygon` and `MultiPolygon` are allowed. Individual stops should be defined in `stops.txt`.
 - Every GeoJSON `Feature` must have an `id`. The `id` belongs to the same namespace as `stop_id` in `stops.txt` and `location_group_id` in `location_groups.txt`, called “stop locations”.
 - Every GeoJSON `Feature` must have a `properties` object, which may have the following keys:
 
@@ -72,7 +71,7 @@ In order for a trip planner to provide a user with information about how to requ
 | &emsp;&emsp;\-&nbsp;`zone_id` | **Conditionally Required** | String | Identifies the fare zone for a stop.<br><br>Conditionally required:<br>- **Required** if `fare_rules.txt` is defined.<br>- Optional otherwise.|
 | &emsp;&emsp;\-&nbsp;`stop_url` | Optional | URL |  URL of a web page about the location.<br><br>If provided, the URL should be different from the `agency.agency_url` and the `routes.route_url` field values. |
 | &emsp;\-&nbsp;`geometry` | **Required** | Object | Geometry of the location. |
-| &emsp;&emsp;\-&nbsp;`type` | **Required** | String | Must be of type:<br>-&nbsp;`"Linestring"`<br>-&nbsp;`"MutiLineString"`<br>-&nbsp;`"Polygon"`<br>-&nbsp;`"MultiPolygon"` |
+| &emsp;&emsp;\-&nbsp;`type` | **Required** | String | Must be of type:<br>-&nbsp;`"Point"`<br>-&nbsp;`"MultiPoint"`<br>-&nbsp;`"Linestring"`<br>-&nbsp;`"MutiLineString"`<br>-&nbsp;`"Polygon"`<br>-&nbsp;`"MultiPolygon"` |
 | &emsp;&emsp;\-&nbsp;`coordinates` | **Required** | Array | Geographic coordinates (latitude and longitude) defining the geometry of the location. |
 
 #### stop_times.txt (file extended)


### PR DESCRIPTION
As discussed in #63. Allow "Point" and "MultiPoint" types in `locations.geojson`.