### PR TITLE
Fixed indentation level of locations.geojson table in the reference.md

### DIFF
--- a/spec/reference.md
+++ b/spec/reference.md
@@ -63,14 +63,14 @@ In order for a trip planner to provide a user with information about how to requ
 | ----- | ----- | ----- | ----- |
 | -&nbsp;`type` | **Required** | String | `"FeatureCollection"` of locations. |
 | -&nbsp;`features` | **Required** | Array | Collection of `"Feature"` objects describing the locations. |
-| &emsp;\-&nbsp;`type` | **Required** | String | `"Feature"` |
-| &emsp;\-&nbsp;`id` | **Required** | String| Location ID belonging to the same namespace as `stops.stop_id`. Therefore, it is forbidden to define an `id` from `locations.geojson` with the same value as a `stops.stop_id`.<br><br>By default, every `id` from `locations.geojson` belongs to a `location_groups.location_group_id` of the same value.|
-| &emsp;\-&nbsp;`properties` | **Required** | Object | Location property keys. |
+| &nbsp;&nbsp;\-&nbsp;`type` | **Required** | String | `"Feature"` |
+| &nbsp;&nbsp;\-&nbsp;`id` | **Required** | String| Location ID belonging to the same namespace as `stops.stop_id`. Therefore, it is forbidden to define an `id` from `locations.geojson` with the same value as a `stops.stop_id`.<br><br>By default, every `id` from `locations.geojson` belongs to a `location_groups.location_group_id` of the same value.|
+| &nbsp;&nbsp;\-&nbsp;`properties` | **Required** | Object | Location property keys. |
 | &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_name` | Optional | String | Indicates the name of the location as displayed to riders. |
 | &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_desc` | Optional | String | Meaningful description of the location to help orient riders. |
 | &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`zone_id` | **Conditionally Required** | String | Identifies the fare zone for a stop.<br><br>Conditionally required:<br>- **Required** if `fare_rules.txt` is defined.<br>- Optional otherwise.|
 | &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_url` | Optional | URL |  URL of a web page about the location.<br><br>If provided, the URL should be different from the `agency.agency_url` and the `routes.route_url` field values. |
-| &emsp;\-&nbsp;`geometry` | **Required** | Object | Geometry of the location. |
+| &nbsp;&nbsp;\-&nbsp;`geometry` | **Required** | Object | Geometry of the location. |
 | &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`type` | **Required** | String | Must be of type:<br>-&nbsp;`"Point"`<br>-&nbsp;`"MultiPoint"`<br>-&nbsp;`"Linestring"`<br>-&nbsp;`"MutiLineString"`<br>-&nbsp;`"Polygon"`<br>-&nbsp;`"MultiPolygon"` |
 | &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`coordinates` | **Required** | Array | Geographic coordinates (latitude and longitude) defining the geometry of the location. |
 

--- a/spec/reference.md
+++ b/spec/reference.md
@@ -63,16 +63,16 @@ In order for a trip planner to provide a user with information about how to requ
 | ----- | ----- | ----- | ----- |
 | -&nbsp;`type` | **Required** | String | `"FeatureCollection"` of locations. |
 | -&nbsp;`features` | **Required** | Array | Collection of `"Feature"` objects describing the locations. |
-| &nbsp;&nbsp;\-&nbsp;`type` | **Required** | String | `"Feature"` |
-| &nbsp;&nbsp;\-&nbsp;`id` | **Required** | String| Location ID belonging to the same namespace as `stops.stop_id`. Therefore, it is forbidden to define an `id` from `locations.geojson` with the same value as a `stops.stop_id`.<br><br>By default, every `id` from `locations.geojson` belongs to a `location_groups.location_group_id` of the same value.|
-| &nbsp;&nbsp;\-&nbsp;`properties` | **Required** | Object | Location property keys. |
-| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_name` | Optional | String | Indicates the name of the location as displayed to riders. |
-| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_desc` | Optional | String | Meaningful description of the location to help orient riders. |
-| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`zone_id` | **Conditionally Required** | String | Identifies the fare zone for a stop.<br><br>Conditionally required:<br>- **Required** if `fare_rules.txt` is defined.<br>- Optional otherwise.|
-| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_url` | Optional | URL |  URL of a web page about the location.<br><br>If provided, the URL should be different from the `agency.agency_url` and the `routes.route_url` field values. |
-| &nbsp;&nbsp;\-&nbsp;`geometry` | **Required** | Object | Geometry of the location. |
-| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`type` | **Required** | String | Must be of type:<br>-&nbsp;`"Point"`<br>-&nbsp;`"MultiPoint"`<br>-&nbsp;`"Linestring"`<br>-&nbsp;`"MutiLineString"`<br>-&nbsp;`"Polygon"`<br>-&nbsp;`"MultiPolygon"` |
-| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`coordinates` | **Required** | Array | Geographic coordinates (latitude and longitude) defining the geometry of the location. |
+| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`type` | **Required** | String | `"Feature"` |
+| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`id` | **Required** | String| Location ID belonging to the same namespace as `stops.stop_id`. Therefore, it is forbidden to define an `id` from `locations.geojson` with the same value as a `stops.stop_id`.<br><br>By default, every `id` from `locations.geojson` belongs to a `location_groups.location_group_id` of the same value.|
+| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`properties` | **Required** | Object | Location property keys. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_name` | Optional | String | Indicates the name of the location as displayed to riders. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_desc` | Optional | String | Meaningful description of the location to help orient riders. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`zone_id` | **Conditionally Required** | String | Identifies the fare zone for a stop.<br><br>Conditionally required:<br>- **Required** if `fare_rules.txt` is defined.<br>- Optional otherwise.|
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_url` | Optional | URL |  URL of a web page about the location.<br><br>If provided, the URL should be different from the `agency.agency_url` and the `routes.route_url` field values. |
+| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`geometry` | **Required** | Object | Geometry of the location. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`type` | **Required** | String | Must be of type:<br>-&nbsp;`"Point"`<br>-&nbsp;`"MultiPoint"`<br>-&nbsp;`"Linestring"`<br>-&nbsp;`"MutiLineString"`<br>-&nbsp;`"Polygon"`<br>-&nbsp;`"MultiPolygon"` |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`coordinates` | **Required** | Array | Geographic coordinates (latitude and longitude) defining the geometry of the location. |
 
 #### stop_times.txt (file extended)
 

--- a/spec/reference.md
+++ b/spec/reference.md
@@ -66,10 +66,10 @@ In order for a trip planner to provide a user with information about how to requ
 | &emsp;\-&nbsp;`type` | **Required** | String | `"Feature"` |
 | &emsp;\-&nbsp;`id` | **Required** | String| Location ID belonging to the same namespace as `stops.stop_id`. Therefore, it is forbidden to define an `id` from `locations.geojson` with the same value as a `stops.stop_id`.<br><br>By default, every `id` from `locations.geojson` belongs to a `location_groups.location_group_id` of the same value.|
 | &emsp;\-&nbsp;`properties` | **Required** | Object | Location property keys. |
-| &emsp;&emsp;\-&nbsp;`stop_name` | Optional | String | Indicates the name of the location as displayed to riders. |
-| &emsp;&emsp;\-&nbsp;`stop_desc` | Optional | String | Meaningful description of the location to help orient riders. |
-| &emsp;&emsp;\-&nbsp;`zone_id` | **Conditionally Required** | String | Identifies the fare zone for a stop.<br><br>Conditionally required:<br>- **Required** if `fare_rules.txt` is defined.<br>- Optional otherwise.|
-| &emsp;&emsp;\-&nbsp;`stop_url` | Optional | URL |  URL of a web page about the location.<br><br>If provided, the URL should be different from the `agency.agency_url` and the `routes.route_url` field values. |
+| &nbsp;&nbsp;\-&nbsp;`stop_name` | Optional | String | Indicates the name of the location as displayed to riders. |
+| &nbsp;&nbsp;\-&nbsp;`stop_desc` | Optional | String | Meaningful description of the location to help orient riders. |
+| &nbsp;&nbsp;\-&nbsp;`zone_id` | **Conditionally Required** | String | Identifies the fare zone for a stop.<br><br>Conditionally required:<br>- **Required** if `fare_rules.txt` is defined.<br>- Optional otherwise.|
+| &nbsp;&nbsp;\-&nbsp;`stop_url` | Optional | URL |  URL of a web page about the location.<br><br>If provided, the URL should be different from the `agency.agency_url` and the `routes.route_url` field values. |
 | &emsp;\-&nbsp;`geometry` | **Required** | Object | Geometry of the location. |
 | &emsp;&emsp;\-&nbsp;`type` | **Required** | String | Must be of type:<br>-&nbsp;`"Point"`<br>-&nbsp;`"MultiPoint"`<br>-&nbsp;`"Linestring"`<br>-&nbsp;`"MutiLineString"`<br>-&nbsp;`"Polygon"`<br>-&nbsp;`"MultiPolygon"` |
 | &emsp;&emsp;\-&nbsp;`coordinates` | **Required** | Array | Geographic coordinates (latitude and longitude) defining the geometry of the location. |

--- a/spec/reference.md
+++ b/spec/reference.md
@@ -66,13 +66,13 @@ In order for a trip planner to provide a user with information about how to requ
 | &emsp;\-&nbsp;`type` | **Required** | String | `"Feature"` |
 | &emsp;\-&nbsp;`id` | **Required** | String| Location ID belonging to the same namespace as `stops.stop_id`. Therefore, it is forbidden to define an `id` from `locations.geojson` with the same value as a `stops.stop_id`.<br><br>By default, every `id` from `locations.geojson` belongs to a `location_groups.location_group_id` of the same value.|
 | &emsp;\-&nbsp;`properties` | **Required** | Object | Location property keys. |
-| &nbsp;&nbsp;\-&nbsp;`stop_name` | Optional | String | Indicates the name of the location as displayed to riders. |
-| &nbsp;&nbsp;\-&nbsp;`stop_desc` | Optional | String | Meaningful description of the location to help orient riders. |
-| &nbsp;&nbsp;\-&nbsp;`zone_id` | **Conditionally Required** | String | Identifies the fare zone for a stop.<br><br>Conditionally required:<br>- **Required** if `fare_rules.txt` is defined.<br>- Optional otherwise.|
-| &nbsp;&nbsp;\-&nbsp;`stop_url` | Optional | URL |  URL of a web page about the location.<br><br>If provided, the URL should be different from the `agency.agency_url` and the `routes.route_url` field values. |
+| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_name` | Optional | String | Indicates the name of the location as displayed to riders. |
+| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_desc` | Optional | String | Meaningful description of the location to help orient riders. |
+| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`zone_id` | **Conditionally Required** | String | Identifies the fare zone for a stop.<br><br>Conditionally required:<br>- **Required** if `fare_rules.txt` is defined.<br>- Optional otherwise.|
+| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`stop_url` | Optional | URL |  URL of a web page about the location.<br><br>If provided, the URL should be different from the `agency.agency_url` and the `routes.route_url` field values. |
 | &emsp;\-&nbsp;`geometry` | **Required** | Object | Geometry of the location. |
-| &emsp;&emsp;\-&nbsp;`type` | **Required** | String | Must be of type:<br>-&nbsp;`"Point"`<br>-&nbsp;`"MultiPoint"`<br>-&nbsp;`"Linestring"`<br>-&nbsp;`"MutiLineString"`<br>-&nbsp;`"Polygon"`<br>-&nbsp;`"MultiPolygon"` |
-| &emsp;&emsp;\-&nbsp;`coordinates` | **Required** | Array | Geographic coordinates (latitude and longitude) defining the geometry of the location. |
+| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`type` | **Required** | String | Must be of type:<br>-&nbsp;`"Point"`<br>-&nbsp;`"MultiPoint"`<br>-&nbsp;`"Linestring"`<br>-&nbsp;`"MutiLineString"`<br>-&nbsp;`"Polygon"`<br>-&nbsp;`"MultiPolygon"` |
+| &nbsp;&nbsp;&nbsp;&nbsp;\-&nbsp;`coordinates` | **Required** | Array | Geographic coordinates (latitude and longitude) defining the geometry of the location. |
 
 #### stop_times.txt (file extended)
 


### PR DESCRIPTION
As discussed in #68, there was an issue with the indentation in the locations.geojson table not rendering properly on Firefox. We replaced the HTML `&esmp; ` to `&nbsp;`. 